### PR TITLE
Release 5.13.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
 env:
   GH_USER_NAME: github.actor
   SCRIPTS_VERSION: 5.14.0
-  BOM_VERSION: 5.14.2
+  BOM_VERSION: 5.15.2
 
 jobs:
   release:

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ apply from: 'project-properties.gradle'
 apply from: 'jooq.gradle'
 apply from: 'ui.gradle'
 
-def scriptsUrl = 'https://raw.githubusercontent.com/reportportal/gradle-scripts/develop'
+def scriptsUrl = 'https://raw.githubusercontent.com/reportportal/gradle-scripts/5.14.0'
 
 apply from: scriptsUrl + '/release-fat.gradle'
 apply from: scriptsUrl + '/signing.gradle'
@@ -24,7 +24,7 @@ repositories {
 
 dependencyManagement {
     imports {
-        mavenBom(releaseMode ? 'com.epam.reportportal:commons-bom:' + getProperty('bom.version') : 'com.epam.reportportal:commons-bom:5.12.1')
+        mavenBom(releaseMode ? 'com.epam.reportportal:commons-bom:' + getProperty('bom.version') : 'com.epam.reportportal:commons-bom:5.15.2')
     }
 }
 
@@ -36,9 +36,9 @@ dependencies {
         implementation 'com.epam.reportportal:plugin-api'
         annotationProcessor 'com.epam.reportportal:plugin-api'
     } else {
-        implementation 'com.github.reportportal:commons-dao:cc743b26'
-        implementation 'com.github.reportportal:plugin-api:a4324ce'
-        annotationProcessor 'com.github.reportportal:plugin-api:a4324ce'
+        implementation 'com.github.reportportal:commons-dao:5.15.4'
+        implementation 'com.github.reportportal:plugin-api:5.15.0'
+        annotationProcessor 'com.github.reportportal:plugin-api:5.15.0'
     }
 
     // add lombok support

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=5.13.1
+version=5.13.2
 description=EPAM Report Portal. GitLab plugin.
 pluginId = GitLab
 

--- a/src/main/java/com/epam/reportportal/extension/gitlab/utils/GitlabObjectMapperProvider.java
+++ b/src/main/java/com/epam/reportportal/extension/gitlab/utils/GitlabObjectMapperProvider.java
@@ -3,28 +3,28 @@ package com.epam.reportportal.extension.gitlab.utils;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import lombok.Getter;
 
 /**
  * @author Zsolt Nagyaghy
  */
+@Getter
 public class GitlabObjectMapperProvider {
-    private final ObjectMapper objectMapper;
 
-    public GitlabObjectMapperProvider() {
-        this.objectMapper = new ObjectMapper();
+  private final ObjectMapper objectMapper;
 
-        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+  public GitlabObjectMapperProvider() {
+    this.objectMapper = new ObjectMapper();
 
-        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-        objectMapper.configure(SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
-        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        objectMapper.configure(DeserializationFeature.READ_ENUMS_USING_TO_STRING, true);
-    }
+    objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+    objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
 
-    public ObjectMapper getObjectMapper() {
-        return objectMapper;
-    }
+    objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+    objectMapper.configure(SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    objectMapper.configure(DeserializationFeature.READ_ENUMS_USING_TO_STRING, true);
+  }
+
 }


### PR DESCRIPTION
Replaces the PropertyNamingStrategy.SNAKE_CASE constant (removed in Jackson 2.20) with PropertyNamingStrategies.SNAKE_CASE, fixing plugin instantiation failure (NoSuchFieldError) on service-api running Jackson 2.21.2.